### PR TITLE
Extend catalog snapshot metadata for offline sync

### DIFF
--- a/backend/audits/api.py
+++ b/backend/audits/api.py
@@ -126,6 +126,14 @@ class OfflineSyncView(LoginRequiredMixin, View):
             "catalog": mapping["catalog"],
             "audits": mapping["audits"],
         }
+        full_snapshot = build_catalog_snapshot_for_user(
+            request.user,
+            include_checklist=True,
+            include_filters=True,
+        )
+        response_payload["catalog_snapshot"] = full_snapshot
+        response_payload["checklist"] = full_snapshot.get("checklist", {})
+        response_payload["audit_filters"] = full_snapshot.get("audit_filters", {})
         batch.mark_applied(response_payload, status=200)
         return JsonResponse(response_payload, status=200)
 
@@ -659,7 +667,11 @@ class CatalogSnapshotView(LoginRequiredMixin, View):
         return super().dispatch(request, *args, **kwargs)
 
     def get(self, request: HttpRequest, *args: object, **kwargs: object) -> JsonResponse:
-        snapshot = build_catalog_snapshot_for_user(request.user)
+        snapshot = build_catalog_snapshot_for_user(
+            request.user,
+            include_checklist=True,
+            include_filters=True,
+        )
         return JsonResponse(snapshot, status=200)
 
 

--- a/backend/audits/services.py
+++ b/backend/audits/services.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from django.db.models import Prefetch
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 
 from catalog.models import (
     Building,
@@ -15,6 +16,9 @@ from catalog.models import (
     ObjectInfoField,
     ScoreOption,
 )
+
+from accounts.permissions import is_admin
+from audits.models import Audit
 
 
 def _serialise_building(building: Building) -> dict[str, Any]:
@@ -59,19 +63,32 @@ def _serialise_object_info_field(field: ObjectInfoField) -> dict[str, Any]:
     }
 
 
-def build_catalog_snapshot_for_user(user: object) -> dict[str, Any]:
-    """Return a catalogue snapshot containing buildings, elevators and object fields."""
+def build_catalog_snapshot_for_user(
+    user: object,
+    *,
+    include_checklist: bool = False,
+    include_filters: bool = False,
+) -> dict[str, Any]:
+    """Return catalogue data visible to the user for offline consumption."""
 
     buildings_qs = Building.objects.visible_for_user(user).select_related("created_by__profile")
     elevators_qs = Elevator.objects.visible_for_user(user).select_related("building")
     fields_qs = ObjectInfoField.objects.all().order_by("order", "label")
 
-    return {
+    snapshot: dict[str, Any] = {
         "generated_at": timezone.now().isoformat(),
         "buildings": [_serialise_building(item) for item in buildings_qs],
         "elevators": [_serialise_elevator(item) for item in elevators_qs],
         "object_fields": [_serialise_object_info_field(item) for item in fields_qs],
     }
+
+    if include_checklist:
+        snapshot["checklist"] = build_checklist_structure()
+
+    if include_filters:
+        snapshot["audit_filters"] = build_audit_filter_snapshot(user)
+
+    return snapshot
 
 
 def _serialise_score_option(option: ScoreOption) -> dict[str, Any]:
@@ -85,7 +102,12 @@ def _serialise_score_option(option: ScoreOption) -> dict[str, Any]:
     }
 
 
-def _serialise_question(question: ChecklistQuestion) -> dict[str, Any]:
+def _serialise_question(
+    question: ChecklistQuestion,
+    *,
+    section: ChecklistSection | None = None,
+    category: ChecklistCategory | None = None,
+) -> dict[str, Any]:
     """Serialise a checklist question along with its available options."""
 
     score_options = []
@@ -99,7 +121,7 @@ def _serialise_question(question: ChecklistQuestion) -> dict[str, Any]:
                     requires_comment_on_reduced_score = True
                     break
 
-    return {
+    data = {
         "id": question.pk,
         "text": question.text,
         "type": question.type,
@@ -110,12 +132,30 @@ def _serialise_question(question: ChecklistQuestion) -> dict[str, Any]:
         "score_options": score_options,
     }
 
+    if section is not None:
+        data["section_id"] = section.pk
+        data["section_title"] = section.title
 
-def _serialise_section(section: ChecklistSection) -> dict[str, Any]:
+    if category is not None:
+        data["category_id"] = category.pk
+        data["category_code"] = category.code
+        data["category_name"] = category.name
+
+    return data
+
+
+def _serialise_section(
+    section: ChecklistSection,
+    *,
+    category: ChecklistCategory | None = None,
+) -> dict[str, Any]:
     """Serialise a checklist section with ordered questions."""
 
-    questions = [_serialise_question(question) for question in section.questions.all()]
-    return {
+    questions = [
+        _serialise_question(question, section=section, category=category)
+        for question in section.questions.all()
+    ]
+    data = {
         "id": section.pk,
         "title": section.title,
         "description": section.description,
@@ -123,11 +163,19 @@ def _serialise_section(section: ChecklistSection) -> dict[str, Any]:
         "questions": questions,
     }
 
+    if category is not None:
+        data["category_id"] = category.pk
+
+    return data
+
 
 def _serialise_category(category: ChecklistCategory) -> dict[str, Any]:
     """Serialise checklist category with nested sections."""
 
-    sections = [_serialise_section(section) for section in category.sections.all()]
+    sections = [
+        _serialise_section(section, category=category)
+        for section in category.sections.all()
+    ]
     return {
         "id": category.pk,
         "code": category.code,
@@ -166,4 +214,38 @@ def build_checklist_structure() -> dict[str, Any]:
         "total_questions": total_questions,
         "generated_at": timezone.now().isoformat(),
     }
+
+
+def build_audit_filter_snapshot(user: object | None = None) -> dict[str, Any]:
+    """Return available audit filter options tailored for the given user."""
+
+    status_filters = [("", _("Все статусы"))] + list(Audit.Status.choices)
+    period_filters = [
+        ("", _("За всё время")),
+        ("7", _("За последние 7 дней")),
+        ("30", _("За последние 30 дней")),
+        ("90", _("За последние 90 дней")),
+    ]
+
+    filters: dict[str, list[dict[str, str]]] = {
+        "status": [
+            {"value": value, "label": str(label)} for value, label in status_filters
+        ],
+        "period": [
+            {"value": value, "label": str(label)} for value, label in period_filters
+        ],
+    }
+
+    if user is not None and is_admin(user):
+        review_filters = [
+            ("", _("Все аудиты")),
+            ("pending", _("Ожидают проверки")),
+            ("active", _("В работе")),
+            ("reviewed", _("Просмотренные")),
+        ]
+        filters["review"] = [
+            {"value": value, "label": str(label)} for value, label in review_filters
+        ]
+
+    return filters
 

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -31,6 +31,20 @@ class UserFactory(factory.django.DjangoModelFactory):
     password = factory.PostGenerationMethodCall("set_password", DEFAULT_USER_PASSWORD)
 
     @factory.post_generation
+    def ensure_password_saved(
+        self, create: bool, extracted: object | None, **_: Any
+    ) -> None:
+        """Persist hashed password produced by :meth:`set_password`."""
+
+        if not create:
+            return
+        if extracted is False:
+            return
+        if not self.password:
+            return
+        self.save(update_fields=["password"])
+
+    @factory.post_generation
     def profile(self, create: bool, extracted: dict[str, Any] | None, **kwargs: Any) -> None:
         """Обновляет связанный профиль при необходимости."""
 

--- a/backend/tests/test_offline_features.py
+++ b/backend/tests/test_offline_features.py
@@ -103,6 +103,28 @@ def test_offline_sync_round_trip(client, settings, tmp_path):
         assert body["catalog"]["buildings"][0]["client_id"] == "b-local"
         assert body["catalog"]["elevators"][0]["client_id"] == "e-local"
 
+        snapshot = body.get("catalog_snapshot")
+        assert snapshot is not None
+        assert "checklist" in snapshot
+        assert "audit_filters" in snapshot
+
+        checklist_payload = body.get("checklist")
+        assert checklist_payload is not None
+        if checklist_payload["categories"]:
+            first_category = checklist_payload["categories"][0]
+            if first_category["sections"]:
+                first_section = first_category["sections"][0]
+                if first_section["questions"]:
+                    question_meta = first_section["questions"][0]
+                    assert "category_id" in question_meta
+                    assert "section_id" in question_meta
+
+        filters_payload = body.get("audit_filters")
+        assert filters_payload is not None
+        assert "status" in filters_payload
+        assert "period" in filters_payload
+        assert "review" not in filters_payload
+
         audit_mapping = body["audits"][0]
         audit_id = audit_mapping["id"]
         response_mapping = audit_mapping["responses"][0]

--- a/backend/tests/test_snapshot_services.py
+++ b/backend/tests/test_snapshot_services.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+
+from audits.services import build_audit_filter_snapshot, build_checklist_structure
+
+from .factories import (
+    AdminUserFactory,
+    AuditorUserFactory,
+    ChecklistQuestionFactory,
+)
+from accounts.permissions import is_admin
+
+
+@pytest.mark.django_db
+def test_checklist_structure_exposes_path_metadata(client) -> None:
+    """Checklist snapshot should expose category and section references."""
+
+    question = ChecklistQuestionFactory()
+
+    structure = build_checklist_structure()
+    assert structure["categories"]
+
+    category = structure["categories"][0]
+    section = category["sections"][0]
+    question_data = section["questions"][0]
+
+    assert question_data["category_id"] == question.section.category_id
+    assert question_data["category_code"] == question.section.category.code
+    assert question_data["category_name"] == question.section.category.name
+    assert question_data["section_id"] == question.section_id
+    assert question_data["section_title"] == question.section.title
+
+
+@pytest.mark.django_db
+def test_audit_filter_snapshot_respects_user_role() -> None:
+    """Administrators should receive review filters, auditors should not."""
+
+    admin_user = AdminUserFactory()
+    auditor_user = AuditorUserFactory()
+
+    admin_filters = build_audit_filter_snapshot(admin_user)
+    assert "status" in admin_filters
+    assert "period" in admin_filters
+    assert "review" in admin_filters
+    assert any(option["value"] == "pending" for option in admin_filters["review"])
+
+    auditor_filters = build_audit_filter_snapshot(auditor_user)
+    assert "status" in auditor_filters
+    assert "period" in auditor_filters
+    assert "review" not in auditor_filters
+
+
+@pytest.mark.django_db
+def test_catalog_snapshot_endpoint_includes_checklist_and_filters(client) -> None:
+    """API snapshot should expose checklist data and filter metadata."""
+
+    admin = AdminUserFactory()
+    admin.profile.mark_password_changed()
+    assert admin.profile.role == admin.profile.Roles.ADMIN
+    assert is_admin(admin)
+    ChecklistQuestionFactory()
+    assert client.login(username=admin.username, password="Password123!")
+
+    response = client.get(reverse("catalog-snapshot"))
+    if response.status_code != 200:
+        request_user = response.wsgi_request.user
+        details = {
+            "is_authenticated": getattr(request_user, "is_authenticated", False),
+            "role": getattr(getattr(request_user, "profile", None), "role", None),
+        }
+        pytest.fail(
+            f"Unexpected response {response.status_code}: {response.json()} with user details {details}"
+        )
+    payload = response.json()
+
+    assert "checklist" in payload
+    assert payload["checklist"]["categories"]
+    assert "audit_filters" in payload
+    assert any(option["value"] == "pending" for option in payload["audit_filters"]["review"])


### PR DESCRIPTION
## Summary
- extend catalog snapshot building helpers with checklist path metadata and audit filter options that are restricted for non-admin users
- include checklist and filter details in catalog snapshot API and offline sync responses for role-aware offline clients
- add snapshot service tests covering metadata, filter snapshots, and API integration, ensuring factories persist hashed passwords for login-based tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cee11702908328925cd1c5fddb7d84