### PR TITLE
Support checklist options with scores

### DIFF
--- a/backend/audits/forms.py
+++ b/backend/audits/forms.py
@@ -79,10 +79,13 @@ class AuditItemForm(BootstrapFormMixin, forms.Form):
             option_field.widget = forms.HiddenInput()
             option_field.initial = ""
         else:
-            options = item.normalized_options()
+            options = list(item.option_definitions())
             option_field.widget = forms.Select(
                 choices=[("", _("Выберите вариант"))]
-                + [(choice, choice) for choice in options]
+                + [
+                    (option.label, option.display_label)
+                    for option in options
+                ]
             )
             numeric_field.widget = forms.HiddenInput()
             numeric_field.help_text = ""
@@ -130,7 +133,7 @@ class AuditItemForm(BootstrapFormMixin, forms.Form):
             cleaned["selected_option"] = ""
         else:
             option = cleaned.get("selected_option", "") or ""
-            if option and option not in item.normalized_options():
+            if option and item.find_option_by_label(option) is None:
                 self.add_error(
                     "selected_option",
                     _("Выбран недопустимый вариант ответа."),

--- a/backend/templates/checklists/template_detail.html
+++ b/backend/templates/checklists/template_detail.html
@@ -73,7 +73,7 @@
                   {% if item.score_type == 'numeric' %}
                     Диапазон: {{ item.min_score }} – {{ item.max_score }}, шаг {{ item.step }}
                   {% else %}
-                    Варианты: {{ item.normalized_options|join:", " }}
+                    Варианты: {{ item.formatted_options|join:", " }}
                   {% endif %}
                 </div>
               </div>

--- a/tests/test_audit_models.py
+++ b/tests/test_audit_models.py
@@ -7,6 +7,31 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 
 from audits.models import Audit, AuditResponse
+from checklists.models import ChecklistItem
+
+
+@pytest.mark.django_db
+def test_option_response_contributes_to_score(
+    audit_factory,
+    checklist_item_factory,
+):
+    audit = audit_factory()
+    option_item = checklist_item_factory(
+        template=audit.template,
+        order=1,
+        score_type=ChecklistItem.ScoreType.OPTION,
+        options=["0 - Не соответствует", "5 - Соответствует"],
+    )
+
+    response = AuditResponse(
+        audit=audit,
+        item=option_item,
+        selected_option="Соответствует",
+    )
+    response.save()
+
+    audit.refresh_from_db()
+    assert audit.score == Decimal("5.00")
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- represent checklist options as structured definitions that store numeric scores alongside labels
- update audit forms and scoring logic to validate selectable answers and include option scores in the total
- enhance checklist import/export to derive options from criteria text, default optional columns, and cover the new behaviour with tests

## Testing
- pytest
- ruff check
- python backend/manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d026a7d8f48328a80a3f396555eb47